### PR TITLE
Update service_point.sqf

### DIFF
--- a/service_point.sqf
+++ b/service_point.sqf
@@ -47,7 +47,8 @@ _cycleTime = 5; // Time in sections for how often the action menu will be refres
 // refuel settings
 _refuel_enable = true; // enable or disable the refuel option
 _refuel_costs = [
-	["All","free"] // All vehicles are free to refuel.
+	["Land","free"], // All land vehicles are free to refuel. Free has to be in ""
+	["Air",1000]	//1000 worth is 1 10oz gold for all air vehicles
 ];
 _refuel_updateInterval = 1; // update interval (in seconds)
 _refuel_amount = 0.05; // amount of fuel to add with every update (in percent)


### PR DESCRIPTION
I added another refuel cost example just to show that you have to write 'free' into "" and the number of coins with no "". Some people forgot that when they installed it and wondered why ingame in scroll menu only was written "Refuel" but no price and it didn't work.